### PR TITLE
gobble spaces after backslash-hardline-break

### DIFF
--- a/flexmark-core-test/src/test/java/com/vladsch/flexmark/core/test/util/parser/ParserTest.java
+++ b/flexmark-core-test/src/test/java/com/vladsch/flexmark/core/test/util/parser/ParserTest.java
@@ -313,6 +313,77 @@ final public class ParserTest {
         assertFalse(it.hasNext());
     }
 
+    @Test
+    public void assertSpacesHardLineBreak() {
+
+        //---------------------- - -1----------
+        //--------------01234567 8 901234567890 
+        String given = "line1  \r\n     line2";
+        Parser parser = Parser.builder().build();
+        Document document = parser.parse(given);
+
+        assertThat(document.getFirstChild(), instanceOf(Paragraph.class));
+        ReversiblePeekingIterator<Node> it = document.getFirstChild().getChildIterator();
+
+        assertTrue(it.hasNext());
+        Node node = it.next();
+        assertThat(node, instanceOf(Text.class));
+        assertEquals("line1", node.getChars().toString());
+        assertEquals(0, node.getStartOffset());
+        assertEquals(5, node.getEndOffset());
+
+        assertTrue(it.hasNext());
+        node = it.next();
+        assertThat(node, instanceOf(HardLineBreak.class));
+        assertEquals(5, node.getStartOffset());
+        assertEquals(9, node.getEndOffset());
+
+        assertTrue(it.hasNext());
+        node = it.next();
+        assertThat(node, instanceOf(Text.class));
+        assertEquals("line2", node.getChars().toString());
+        assertEquals(14, node.getStartOffset());
+        assertEquals(19, node.getEndOffset());
+
+        assertFalse(it.hasNext());
+    }
+
+    @Test
+    public void assertBackslashHardLineBreak() {
+
+        //-------------------- - - --1----------
+        //--------------012345 6 7 8901234567890 
+        String given = "line1\\\r\n     line2";
+        Parser parser = Parser.builder().build();
+        Document document = parser.parse(given);
+
+        assertThat(document.getFirstChild(), instanceOf(Paragraph.class));
+        ReversiblePeekingIterator<Node> it = document.getFirstChild().getChildIterator();
+
+        assertTrue(it.hasNext());
+        Node node = it.next();
+        assertThat(node, instanceOf(Text.class));
+        assertEquals("line1", node.getChars().toString());
+        assertEquals(0, node.getStartOffset());
+        assertEquals(5, node.getEndOffset());
+
+        assertTrue(it.hasNext());
+        node = it.next();
+        assertThat(node, instanceOf(HardLineBreak.class));
+        assertEquals(5, node.getStartOffset());
+        assertEquals(8, node.getEndOffset());
+
+        assertTrue(it.hasNext());
+        node = it.next();
+        assertThat(node, instanceOf(Text.class));
+        assertEquals("line2", node.getChars().toString());
+        assertEquals(13, node.getStartOffset());
+        assertEquals(18, node.getEndOffset());
+
+        assertFalse(it.hasNext());
+    }
+
+    
     String escape(String input, Parser parser) {
         BasedSequence baseSeq = BasedSequence.of(input);
         List<SpecialLeadInHandler> handlers = Parser.SPECIAL_LEAD_IN_HANDLERS.get(parser.getOptions());

--- a/flexmark-core-test/src/test/resources/ast_spec.md
+++ b/flexmark-core-test/src/test/resources/ast_spec.md
@@ -12815,7 +12815,7 @@ Document[0, 14]
   Paragraph[0, 14]
     Text[0, 3] chars:[0, 3, "foo"]
     HardLineBreak[3, 5]
-    Text[10, 13] chars:[10, 13, "     bar"]
+    Text[10, 13] chars:[10, 13, "bar"]
 ````````````````````````````````
 
 

--- a/flexmark/src/main/java/com/vladsch/flexmark/parser/internal/InlineParserImpl.java
+++ b/flexmark/src/main/java/com/vladsch/flexmark/parser/internal/InlineParserImpl.java
@@ -524,9 +524,8 @@ public class InlineParserImpl extends LightInlineParserImpl implements InlinePar
         }
 
         // gobble leading spaces in next line
-        while (peek() == ' ') {
-            index++;
-        }
+        gobbleLeadingSpaces();
+
         return true;
     }
 
@@ -542,6 +541,7 @@ public class InlineParserImpl extends LightInlineParserImpl implements InlinePar
             int charsMatched = peek(1) == '\n' ? 2 : 1;
             appendNode(new HardLineBreak(input.subSequence(index - 1, index + charsMatched)));
             index += charsMatched;
+            gobbleLeadingSpaces();
         } else if (index < input.length() && myParsing.ESCAPABLE.matcher(input.subSequence(index, index + 1)).matches()) {
             appendText(input, index - 1, index + 1);
             index++;
@@ -549,6 +549,12 @@ public class InlineParserImpl extends LightInlineParserImpl implements InlinePar
             appendText(input.subSequence(index - 1, index));
         }
         return true;
+    }
+    
+    private void gobbleLeadingSpaces() {
+        while (peek() == ' ') {
+            index++;
+        }
     }
 
     /**


### PR DESCRIPTION
After a line break the leading spaces of the next line are consumed (at the end of `InlineParserImpl::parseNewLine()`). However,  `InlineParserImpl::parseNewLine()` does **not** handle **all** kinds of ending a line: The backslash-hardline-break is handled in `InlineParserImpl::parseBackslash()` instead, so the parser does not consume the leading spaces of the following line for that case. The commit changes that so that spaces are consumed there as well now. 

Fixes https://github.com/vsch/flexmark-java/issues/619.